### PR TITLE
Explicitly call finish in synth. Fixes #5

### DIFF
--- a/pymoogi/moog/Synth.f
+++ b/pymoogi/moog/Synth.f
@@ -87,7 +87,7 @@ c*****do the syntheses
       ncall = 1
       call getsyns (lscreen,ncall)
       call smooth (-1,ncall)   
-
+      call finish (0)
       end 
 
 


### PR DESCRIPTION
In the `synth` driver `finish()` was never called and as a result open file descriptors were never closed. On certain operating systems that resulted in truncated output files.